### PR TITLE
Fix implementation for rails 6.1

### DIFF
--- a/lib/rack_password.rb
+++ b/lib/rack_password.rb
@@ -31,6 +31,13 @@ module RackPassword
 
     private
 
+    def app_name
+      return Rails.application.class.module_parent_name if defined?(Rails) && Rails.version.to_i >= 6
+      return Rails.application.class.parent_name if defined?(Rails)
+
+      ''
+    end
+
     def cookie_params(domain, code)
       "#{@options[:key]}=#{code}; "\
       "domain=#{domain}; "\
@@ -48,7 +55,6 @@ module RackPassword
     end
 
     def fill_in_application_name(view)
-      app_name = defined?(Rails) ? Rails.application.class.parent_name : ''
       view.sub('__App_Name__', app_name)
     end
 

--- a/lib/rack_password/version.rb
+++ b/lib/rack_password/version.rb
@@ -1,3 +1,3 @@
 module RackPassword
-  VERSION = '1.4'.freeze
+  VERSION = '1.5'.freeze
 end

--- a/spec/lib/rack_password/block_spec.rb
+++ b/spec/lib/rack_password/block_spec.rb
@@ -6,75 +6,157 @@ module RackPassword
 
     before do
       class Rails; end
-      allow(Rails).to receive_message_chain(:application, :class, :parent_name) { app_name }
       allow(Rack::Request).to receive(:new).and_return(request)
     end
 
-    describe 'for not post requests' do
-      let(:block) { Block.new('app', auth_codes: ['Janusz']) }
-      let(:request) do
-        double(
-          cookies: {},
-          host: 'localhost',
-          params: { 'code' => 'Janusz' },
-          path: '/',
-          post?: false
-        )
+    context 'for Rails 6 or higher' do
+      before do
+        allow(Rails).to receive_message_chain(:application, :class, :module_parent_name) { app_name }
+        allow(Rails).to(receive(:version).and_return(6.0))
       end
 
-      it 'returns 200 status code' do
-        expect(block.call(request)[0]).to eq(200)
-      end
-
-      it 'returns html' do
-        expect(block.call(request)[2][0]).to include('password')
-      end
-
-      it 'fills in application name if used as Rails middleware' do
-        expect(block.call(request)[2][0]).to include(app_name)
-      end
-    end
-
-    describe 'for post requests' do
-      let(:request) do
-        double(
-          cookies: {},
-          host: 'localhost',
-          params: { 'code' => 'Janusz' },
-          path: '/',
-          post?: true
-        )
-      end
-
-      context 'when requests contain proper auth code' do
-        let(:block) { Block.new('app', { auth_codes: ['Janusz'] }) }
-
-        it 'returns 301 status code' do
-          expect(block.call(request)[0]).to eq(301)
+      describe 'for not post requests' do
+        let(:block) { Block.new('app', auth_codes: ['Janusz']) }
+        let(:request) do
+          double(
+            cookies: {},
+            host: 'localhost',
+            params: { 'code' => 'Janusz' },
+            path: '/',
+            post?: false
+          )
         end
 
-        context 'and when "force_cookie_root_path" not used' do
-          it 'does not set root path for the cookie' do
-            expect(block.call(request)[1]['Set-Cookie']).to_not include('path=/')
-          end
+        it 'returns 200 status code' do
+          expect(block.call(request)[0]).to eq(200)
         end
-
-        context 'and when "force_cookie_root_path" used' do
-          let(:block) do
-            Block.new('app', { auth_codes: ['Janusz'], force_cookie_root_path: true })
-          end
-
-          it 'sets root path for the cookie' do
-            expect(block.call(request)[1]['Set-Cookie']).to include('path=/')
-          end
-        end
-      end
-
-      context 'when requests contain invalid auth code' do
-        let(:block) { Block.new('app', { auth_codes: ['Janusz123'] }) }
 
         it 'returns html' do
           expect(block.call(request)[2][0]).to include('password')
+        end
+
+        it 'fills in application name if used as Rails middleware' do
+          expect(block.call(request)[2][0]).to include(app_name)
+        end
+      end
+
+      describe 'for post requests' do
+        let(:request) do
+          double(
+            cookies: {},
+            host: 'localhost',
+            params: { 'code' => 'Janusz' },
+            path: '/',
+            post?: true
+          )
+        end
+
+        context 'when requests contain proper auth code' do
+          let(:block) { Block.new('app', { auth_codes: ['Janusz'] }) }
+
+          it 'returns 301 status code' do
+            expect(block.call(request)[0]).to eq(301)
+          end
+
+          context 'and when "force_cookie_root_path" not used' do
+            it 'does not set root path for the cookie' do
+              expect(block.call(request)[1]['Set-Cookie']).to_not include('path=/')
+            end
+          end
+
+          context 'and when "force_cookie_root_path" used' do
+            let(:block) do
+              Block.new('app', { auth_codes: ['Janusz'], force_cookie_root_path: true })
+            end
+
+            it 'sets root path for the cookie' do
+              expect(block.call(request)[1]['Set-Cookie']).to include('path=/')
+            end
+          end
+        end
+
+        context 'when requests contain invalid auth code' do
+          let(:block) { Block.new('app', { auth_codes: ['Janusz123'] }) }
+
+          it 'returns html' do
+            expect(block.call(request)[2][0]).to include('password')
+          end
+        end
+      end
+    end
+
+    context 'for older than Rails 6' do
+      before do
+        allow(Rails).to receive_message_chain(:application, :class, :parent_name) { app_name }
+        allow(Rails).to(receive(:version).and_return(5.2))
+      end
+
+      describe 'for not post requests' do
+        let(:block) { Block.new('app', auth_codes: ['Janusz']) }
+        let(:request) do
+          double(
+            cookies: {},
+            host: 'localhost',
+            params: { 'code' => 'Janusz' },
+            path: '/',
+            post?: false
+          )
+        end
+
+        it 'returns 200 status code' do
+          expect(block.call(request)[0]).to eq(200)
+        end
+
+        it 'returns html' do
+          expect(block.call(request)[2][0]).to include('password')
+        end
+
+        it 'fills in application name if used as Rails middleware' do
+          expect(block.call(request)[2][0]).to include(app_name)
+        end
+      end
+
+      describe 'for post requests' do
+        let(:request) do
+          double(
+            cookies: {},
+            host: 'localhost',
+            params: { 'code' => 'Janusz' },
+            path: '/',
+            post?: true
+          )
+        end
+
+        context 'when requests contain proper auth code' do
+          let(:block) { Block.new('app', { auth_codes: ['Janusz'] }) }
+
+          it 'returns 301 status code' do
+            expect(block.call(request)[0]).to eq(301)
+          end
+
+          context 'and when "force_cookie_root_path" not used' do
+            it 'does not set root path for the cookie' do
+              expect(block.call(request)[1]['Set-Cookie']).to_not include('path=/')
+            end
+          end
+
+          context 'and when "force_cookie_root_path" used' do
+            let(:block) do
+              Block.new('app', { auth_codes: ['Janusz'], force_cookie_root_path: true })
+            end
+
+            it 'sets root path for the cookie' do
+              expect(block.call(request)[1]['Set-Cookie']).to include('path=/')
+            end
+          end
+        end
+
+        context 'when requests contain invalid auth code' do
+          let(:block) { Block.new('app', { auth_codes: ['Janusz123'] }) }
+
+          it 'returns html' do
+            expect(block.call(request)[2][0]).to include('password')
+          end
         end
       end
     end


### PR DESCRIPTION
Fix implementation for Rails 6.1 (the `module_parent_name` is used instead of `parent_name` after deprecating it for Rails 6.0). To make it working for all our apps, we just have to use newer method for apps using Rails 6.0 or higher.